### PR TITLE
Add individual params to tween

### DIFF
--- a/src/group/group.js
+++ b/src/group/group.js
@@ -160,6 +160,7 @@ class Group extends EventEmitter {
 
       // initiate an empty gsap timeline
       if (this.timeline && this.timeline instanceof config.gsap.timeline) {
+        this.timeline.stop()
         this.timeline.kill()
         this.timeline.clear()
       } else {

--- a/src/group/index.js
+++ b/src/group/index.js
@@ -1,21 +1,9 @@
-import Group from './group'
-import Groups from './groups'
-import EvalMap from './evalmap'
-import Param from './param'
-import Params from './params'
-import Timeline from './timeline'
-import Timelines from './timelines'
-import Transition from './transition'
-import Transitions from './transitions'
-
-export {
-  Group,
-  Groups,
-  EvalMap,
-  Param,
-  Params,
-  Timeline,
-  Timelines,
-  Transition,
-  Transitions
-}
+export Group from './group'
+export Groups from './groups'
+export EvalMap from './evalmap'
+export Param from './param'
+export Params from './params'
+export Timeline from './timeline'
+export Timelines from './timelines'
+export Transition from './transition'
+export Transitions from './transitions'


### PR DESCRIPTION
Prevent transform clustering from transition to transition.

## Issue

Let's say we have to following transitions for a timeline:

```
frame 1:      { x: 0 }
frame 10:     { y: 10 }
frame 20:     { x: 100 }
frame 30:     { y: 100 }
```

- We move property `x` from `1-20` frames.
- We move property `y` from `10-30` frames.

**Expected behaviour**

If we scrub across the frames, we'd expect that property `x` has moved independently from property `y`. Because all properties are bundled to the GSAP timeline per transition it gives this unwanted behaviour.

## Solution

Add each param separately to the main GSAP timeline and set the start time and duration to the param's previous frame.