### PR TITLE
Parse root from data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spirit (GSAP) Runtime
+# Spirit - Runtime player
 
 Spirit is the animation tool for the web. 
 

--- a/test/config-spec.js
+++ b/test/config-spec.js
@@ -7,6 +7,7 @@ const configGsap = { ...config.gsap }
 describe('config', () => {
 
   beforeEach(() => {
+    config.gsap.autoInjectUrl = 'test/fixtures/gsap.js'
     sinon.spy(gsap, 'ensure')
   })
 

--- a/test/fixtures/group/dom.js
+++ b/test/fixtures/group/dom.js
@@ -2,9 +2,9 @@
  * Create a simple post block
  * @returns {Element}
  */
-export function post() {
+export function post(classNames = '') {
   const el = document.createElement('div')
-  el.className = 'post'
+  el.className = 'post ' + classNames
   el.innerHTML = `
 
   <h1>Title Post</h1>

--- a/test/groups-spec.js
+++ b/test/groups-spec.js
@@ -8,6 +8,7 @@ const configGsap = { ...config.gsap }
 describe('groups', () => {
 
   before(async() => {
+    config.gsap.autoInjectUrl = 'test/fixtures/gsap.js'
     await setup()
   })
 

--- a/test/utils-spec.js
+++ b/test/utils-spec.js
@@ -126,7 +126,7 @@ describe('utils', () => {
   describe('gsap', () => {
 
     beforeEach(() => {
-      config.gsap = { ...gsapConfig }
+      config.gsap.autoInjectUrl = 'test/fixtures/gsap.js'
     })
 
     afterEach(() => {


### PR DESCRIPTION
# Parse root

Resolve root from exported data.

```es6
// use .container as root
spirit.load('groups.json', document.querySelector('.container'))

// try to resolve root from JSON instead
spirit.load('groups.json')
```

The exported data contain the root path/id. If no root is provided, it falls back to `document.body`. Try resolving root from the exported data.