### PR TITLE
Shorthand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ install:
   - npm install --ignore-scripts
 
 node_js:
-  - "6"
   - "stable"
 
 script:

--- a/src/data/parser.js
+++ b/src/data/parser.js
@@ -4,9 +4,9 @@ import { Groups, Group } from '../group'
 /**
  * Get transform object from container
  *
- * @param   {HTMLElement} container
+ * @param   {Element} container
  * @param   {object}      tl
- * @returns {HTMLElement|object}
+ * @returns {Element|object}
  */
 function getTransformObject(container, tl) {
   let transformObject
@@ -132,7 +132,7 @@ function groupsFactory() {
  * Parse groups
  *
  * @param   {object|Array}  data  animation data
- * @param   {HTMLElement}   root  the root element for animation groups
+ * @param   {Element}       root  the root element for animation groups
  * @returns Groups
  */
 export function create(data, root = undefined) {
@@ -212,8 +212,8 @@ export function create(data, root = undefined) {
 /**
  * Load data and apply it to element
  *
- * @param   {string}      url
- * @param   {HTMLElement} root
+ * @param   {string}  url
+ * @param   {Element} root
  * @returns {Promise}
  */
 export function load(url, root = undefined) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,14 +6,18 @@ import config from './config/config'
 import setup from './config/setup'
 import groups from './registry/registry'
 import { create, load } from './data/parser'
+import loadAnimation from './loadAnimation'
 
-const Spirit = function() {
-  this.config = config
-  this.version = version
-  this.setup = setup
-  this.groups = groups
-  this.create = create
-  this.load = load
+const Spirit = function() {}
+
+Spirit.prototype = {
+  config,
+  version,
+  setup,
+  groups,
+  create,
+  load,
+  loadAnimation
 }
 
 export {
@@ -22,7 +26,8 @@ export {
   setup,
   groups,
   create,
-  load
+  load,
+  loadAnimation
 }
 
 const spirit = new Spirit()

--- a/src/loadAnimation.js
+++ b/src/loadAnimation.js
@@ -54,6 +54,10 @@ export default function(manifest) {
   const options = { ...defaults, ...manifest }
   const { animationData, container, path } = options
 
+  if (options.loop === true) {
+    options.loop = -1
+  }
+
   return new Promise((resolve, reject) => {
     let result = []
     let add = coll => { result = [...result, ...(Array.isArray(coll) ? [...coll] : [coll])] }
@@ -93,7 +97,7 @@ export default function(manifest) {
 
         for (let timeline of timelines) {
           if (options.loop) {
-            timeline.repeat(-1)
+            timeline.repeat(options.loop)
           }
 
           if (options.yoyo) {

--- a/src/loadAnimation.js
+++ b/src/loadAnimation.js
@@ -1,0 +1,115 @@
+import setup from './config/setup'
+import { create, load } from './data/parser'
+import { isObject } from './utils/is'
+import config from './config/config'
+
+const defaults = {
+  loop: false,
+  autoPlay: true,
+  yoyo: false,
+  delay: 0,
+  timeScale: false
+}
+
+/**
+ * Create from data
+ *
+ * @param {object|Array} data
+ * @param {Element}      container
+ * @return {Promise<Array|object>}
+ */
+function createFromData(data, container) {
+  if (data === undefined) {
+    return Promise.resolve([])
+  }
+
+  if (!(isObject(data) || Array.isArray(data))) {
+    return Promise.reject(new Error('Invalid animation data'))
+  }
+  return Promise.resolve(create(data, container))
+}
+
+/**
+ * Load from path
+ *
+ * @param {string}  path
+ * @param {Element} container
+ * @return {Promise<Array|object>}
+ */
+function loadFromPath(path, container) {
+  if (path && typeof path === 'string' && path.length > 0) {
+    return load(path, container)
+  }
+  return Promise.resolve([])
+}
+
+/**
+ * Load animation shorthand
+ *
+ * @param  {object} manifest
+ * @return {Promise<Array|Function>}
+ */
+export default function(manifest) {
+  const options = { ...defaults, ...manifest }
+  const { animationData, container, path } = options
+
+  return new Promise((resolve, reject) => {
+    let result = []
+    let add = coll => result = [...result, ...(Array.isArray(coll) ? [...coll] : [coll])]
+
+    // setup gsap
+    setup()
+      .then(() => Promise.all([
+        createFromData(animationData, container),
+        loadFromPath(path, container)
+      ]))
+      .then(([created, loaded]) => {
+        add(created)
+        add(loaded)
+      })
+      .then(() => {
+        // one animation group, return it's timeline directly
+        if (result.length === 1 && result[0].length === 1) {
+          return result[0][0].construct()
+        }
+
+        // multiple groups!
+        let g = {}
+        for (let groups of result) {
+          for (let group of groups) {
+            g[group.name] = group.construct()
+          }
+        }
+        return g
+      })
+      .then(res => {
+        let timelines = (res instanceof config.gsap.timeline) ? [res] : Object.keys(res).map(k => res[k])
+
+        for (let timeline of timelines) {
+          if (options.loop) {
+            timeline.repeat(-1)
+          }
+
+          if (options.yoyo) {
+            timeline.yoyo(true)
+          }
+
+          if (options.delay !== 0) {
+            timeline.delay(options.delay)
+          }
+
+          if (options.timeScale) {
+            timeline.timeScale(options.timeScale)
+          }
+
+          if (options.autoPlay) {
+            timeline.play(0)
+          }
+        }
+
+        // finally resolve res
+        resolve(res)
+      })
+      .catch(reject)
+  })
+}

--- a/src/loadAnimation.js
+++ b/src/loadAnimation.js
@@ -55,7 +55,7 @@ export default function(manifest) {
 
   return new Promise((resolve, reject) => {
     let result = []
-    let add = coll => result = [...result, ...(Array.isArray(coll) ? [...coll] : [coll])]
+    let add = coll => { result = [...result, ...(Array.isArray(coll) ? [...coll] : [coll])] }
 
     // setup gsap
     setup()

--- a/src/loadAnimation.js
+++ b/src/loadAnimation.js
@@ -2,6 +2,7 @@ import setup from './config/setup'
 import { create, load } from './data/parser'
 import { isObject } from './utils/is'
 import config from './config/config'
+import registry from './registry/registry'
 
 const defaults = {
   loop: false,
@@ -78,6 +79,11 @@ export default function(manifest) {
         for (let groups of result) {
           for (let group of groups) {
             g[group.name] = group.construct()
+            g[group.name].construct = function() {
+              let tl = registry.get(group.name).construct()
+              tl.construct = this.construct
+              return tl
+            }
           }
         }
         return g

--- a/src/utils/xpath.js
+++ b/src/utils/xpath.js
@@ -3,7 +3,7 @@ import { isSVG } from './is'
 /**
  * Get DOM representation for an element.
  *
- * @param   {HTMLElement}                 element
+ * @param   {Element}                     element
  * @param   {null|undefined|HTMLElement}  nodeContext
  * @returns {string|null}
  */

--- a/test/load-animation-spec.js
+++ b/test/load-animation-spec.js
@@ -338,7 +338,6 @@ describe('load-animation', () => {
 
       it('should not loop all groups', async () => {
         const groups = await loadAnimation({
-          autoPlay: true,
           animationData: [
             createSimpleGroup('a', 'div[1]/div[1]'),
             createSimpleGroup('b', 'div[1]/div[2]'),
@@ -346,6 +345,18 @@ describe('load-animation', () => {
           ]
         })
         expect(Object.keys(groups).map(g => groups[g].repeat())).to.deep.equal([0, 0, 0])
+      })
+
+      it('should loop x times', async () => {
+        const groups = await loadAnimation({
+          loop: 2,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].repeat())).to.deep.equal([2, 2, 2])
       })
 
     })

--- a/test/load-animation-spec.js
+++ b/test/load-animation-spec.js
@@ -1,0 +1,477 @@
+import loadAnimation from '../src/loadAnimation'
+import registry from '../src/registry/registry'
+import config from '../src/config/config'
+import { cache, req } from '../src/utils/jsonloader'
+import { is } from '../src/utils'
+import { post } from './fixtures/group/dom'
+
+const gsapConfig = { ...config.gsap }
+
+// helper
+const createContainers = (c, num) => {
+  let inner = ''
+  for (let i = 1; i <= num; i++) {
+    inner += `
+        <div class="container-${i}">
+          ${post(`post-${i}-1`).outerHTML}
+          ${post(`post-${i}-2`).outerHTML}
+          ${post(`post-${i}-3`).outerHTML}
+        </div>
+      `
+  }
+  c.innerHTML = inner
+
+  let result = []
+  for (let i = 1; i <= num; i++) {
+    result.push(document.querySelector(`.container-${i}`))
+  }
+  return result
+}
+
+describe('load-animation', () => {
+  let div
+
+  before(() => { config.gsap.autoInjectUrl = 'test/fixtures/gsap.js' })
+  after(() => { config.gsap = { ...gsapConfig } })
+
+  beforeEach(() => {
+    div = document.createElement('div')
+    document.body.appendChild(div)
+    registry.clear()
+  })
+
+  afterEach(() => {
+    document.body.removeChild(div)
+  })
+
+  describe('parse', () => {
+
+    describe('with animationData', () => {
+
+      it('should create animations from object', async () => {
+        const result = await loadAnimation({ animationData: { name: 'a' } })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry).to.have.lengthOf(1)
+        expect(registry.at(0)).to.have.property('name', 'a')
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', document.body)
+      })
+
+      it('should create animations from array', async () => {
+        const result = await loadAnimation({ animationData: [{ name: 'b' }] })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry).to.have.lengthOf(1)
+        expect(registry.at(0)).to.have.property('name', 'b')
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', document.body)
+      })
+
+      it('should create animations from multi array', async () => {
+        const result = await loadAnimation({
+          animationData: [
+            { name: 'a' },
+            { name: 'b' },
+            { name: 'c' }
+          ]
+        })
+
+        expect(result).to.be.an('object')
+        expect(result).to.have.all.keys('a', 'b', 'c')
+
+        expect(registry).to.have.lengthOf(3)
+        expect(registry.at(0)).to.have.property('name', 'a')
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', document.body)
+        expect(registry.at(1)).to.have.property('name', 'b')
+        expect(registry.at(1)).to.have.deep.property('_list.rootEl', document.body)
+        expect(registry.at(2)).to.have.property('name', 'c')
+        expect(registry.at(2)).to.have.deep.property('_list.rootEl', document.body)
+      })
+
+      it('should create animations assigned to container', async () => {
+        const result = await loadAnimation({
+          container: div,
+          animationData: { name: 'ghost' }
+        })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', div)
+      })
+
+      it('should create groups with parsed root', async () => {
+        const containers = createContainers(div, 1)
+        const result = await loadAnimation({
+          animationData: {
+            name: 'ghost-animation',
+            root: { path: 'div[1]/div[1]' }
+          }
+        })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', containers[0])
+      })
+
+      it('should create multiple groups with parsed roots', async () => {
+        const containers = createContainers(div, 3)
+
+        const result = await loadAnimation({
+          animationData: [
+            { name: 'a', root: { path: 'div[1]/div[1]' } },
+            { name: 'b', root: { path: 'div[1]/div[2]' } },
+            { name: 'c', root: { path: 'div[1]/div[3]' } },
+          ]
+        })
+
+        expect(result).to.be.an('object')
+        expect(result).to.have.all.keys('a', 'b', 'c')
+
+        expect(registry.at(0)).deep.have.deep.property('_list.rootEl', containers[0])
+        expect(registry.at(1)).deep.have.deep.property('_list.rootEl', containers[1])
+        expect(registry.at(2)).deep.have.deep.property('_list.rootEl', containers[2])
+      })
+
+      it('should throw error on invalid animation data', async () => {
+        const load = animationData => resolvePromise(loadAnimation({ animationData }))
+
+        expect(await load('aa')).to.be.an('error').to.match(/Invalid animation data/)
+        expect(await load(1234)).to.be.an('error').to.match(/Invalid animation data/)
+        expect(await load({})).to.be.an('error').to.match(/Cannot create group without a name/)
+      })
+
+    })
+
+    describe('with load path', () => {
+      let sandbox
+
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create()
+      })
+
+      afterEach(() => {
+        sandbox.restore()
+        Object.keys(cache).forEach(key => delete cache[key])
+        Object.keys(req).forEach(key => delete req[key])
+      })
+
+      it('should create animations from object', async () => {
+        stubXhr(sandbox, { responseText: JSON.stringify({ name: 'a' }) })
+
+        const result = await loadAnimation({ path: 'animation.json' })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry).to.have.lengthOf(1)
+        expect(registry.at(0)).to.have.property('name', 'a')
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', document.body)
+      })
+
+      it('should create animations from array', async () => {
+        stubXhr(sandbox, { responseText: JSON.stringify([{ name: 'b' }]) })
+
+        const result = await loadAnimation({ path: 'animation.json' })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry).to.have.lengthOf(1)
+        expect(registry.at(0)).to.have.property('name', 'b')
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', document.body)
+      })
+
+      it('should create animations from multi array', async () => {
+        stubXhr(sandbox, {
+          responseText: JSON.stringify([
+            { name: 'a' },
+            { name: 'b' },
+            { name: 'c' }
+          ])
+        })
+
+        const result = await loadAnimation({ path: 'animation.json' })
+
+        expect(result).to.be.an('object')
+        expect(result).to.have.all.keys('a', 'b', 'c')
+
+        expect(registry).to.have.lengthOf(3)
+        expect(registry.at(0)).to.have.property('name', 'a')
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', document.body)
+        expect(registry.at(1)).to.have.property('name', 'b')
+        expect(registry.at(1)).to.have.deep.property('_list.rootEl', document.body)
+        expect(registry.at(2)).to.have.property('name', 'c')
+        expect(registry.at(2)).to.have.deep.property('_list.rootEl', document.body)
+      })
+
+      it('should create animations assigned to container', async () => {
+        stubXhr(sandbox, { responseText: JSON.stringify({ name: 'ghost' }) })
+
+        const result = await loadAnimation({
+          container: div,
+          path: 'animations.json'
+        })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', div)
+      })
+
+      it('should create groups with parsed root', async () => {
+        stubXhr(sandbox, {
+          responseText: JSON.stringify({
+            name: 'ghost-animation',
+            root: { path: 'div[1]/div[1]' }
+          })
+        })
+
+        const containers = createContainers(div, 1)
+        const result = await loadAnimation({ path: 'animation.json' })
+
+        expect(result).to.be.an.instanceOf(config.gsap.timeline)
+        expect(registry.at(0)).to.have.deep.property('_list.rootEl', containers[0])
+      })
+
+      it('should create multiple groups with parsed roots', async () => {
+        stubXhr(sandbox, {
+          responseText: JSON.stringify([
+            { name: 'a', root: { path: 'div[1]/div[1]' } },
+            { name: 'b', root: { path: 'div[1]/div[2]' } },
+            { name: 'c', root: { path: 'div[1]/div[3]' } },
+          ])
+        })
+
+        const containers = createContainers(div, 3)
+        const result = await loadAnimation({ path: 'animation.json' })
+
+        expect(result).to.be.an('object')
+        expect(result).to.have.all.keys('a', 'b', 'c')
+
+        expect(registry.at(0)).deep.have.deep.property('_list.rootEl', containers[0])
+        expect(registry.at(1)).deep.have.deep.property('_list.rootEl', containers[1])
+        expect(registry.at(2)).deep.have.deep.property('_list.rootEl', containers[2])
+      })
+
+    })
+
+  })
+
+  describe('features', () => {
+    let sandbox
+
+    const createSimpleGroup = (name, path, opts = {}, props = { x: { '0s': 0, '0.001s': 100 } }) => ({
+      name, timelines: [{ path, props }], ...opts
+    })
+
+    before(() => {
+      sandbox = sinon.sandbox.create()
+      sandbox.stub(is, 'isSVG', element => ['SVG', 'G', 'RECT'].includes(element.nodeName))
+    })
+
+    after(() => {
+      sandbox.restore()
+    })
+
+    beforeEach(function() {
+      createContainers(div, 3)
+    })
+
+    describe('autoPlay', () => {
+
+      it('should auto play single group', async () => {
+        const timeline = await loadAnimation({ animationData: createSimpleGroup('a', 'div[1]') })
+        expect(timeline.isActive()).to.be.true
+      })
+
+      it('should not auto play single group', async () => {
+        const timeline = await loadAnimation({
+          autoPlay: false,
+          animationData: createSimpleGroup('a', 'div[1]')
+        })
+        expect(timeline.isActive()).to.be.false
+      })
+
+      it('should auto play all groups', async () => {
+        const groups = await loadAnimation({
+          autoPlay: true,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].isActive())).to.deep.equal([true, true, true])
+      })
+
+      it('should not auto play all groups', async () => {
+        const groups = await loadAnimation({
+          autoPlay: false,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].isActive())).to.deep.equal([false, false, false])
+      })
+
+    })
+
+    describe('loop', () => {
+
+      it('should not loop single group', async () => {
+        const timeline = await loadAnimation({ animationData: createSimpleGroup('a', 'div[1]') })
+        expect(timeline.repeat()).to.equal(0)
+      })
+
+      it('should loop single group', async () => {
+        const timeline = await loadAnimation({
+          loop: true,
+          animationData: createSimpleGroup('a', 'div[1]')
+        })
+        expect(timeline.repeat()).to.equal(-1)
+      })
+
+      it('should loop all groups', async () => {
+        const groups = await loadAnimation({
+          loop: true,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].repeat())).to.deep.equal([-1, -1, -1])
+      })
+
+      it('should not loop all groups', async () => {
+        const groups = await loadAnimation({
+          autoPlay: true,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].repeat())).to.deep.equal([0, 0, 0])
+      })
+
+    })
+
+    describe('yoyo', () => {
+
+      it('should not yoyo single group', async () => {
+        const timeline = await loadAnimation({ animationData: createSimpleGroup('a', 'div[1]') })
+        expect(timeline.yoyo()).to.be.false
+      })
+
+      it('should yoyo single group', async () => {
+        const timeline = await loadAnimation({
+          yoyo: true,
+          animationData: createSimpleGroup('a', 'div[1]')
+        })
+        expect(timeline.yoyo()).to.be.true
+      })
+
+      it('should yoyo all groups', async () => {
+        const groups = await loadAnimation({
+          yoyo: true,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].yoyo())).to.deep.equal([true, true, true])
+      })
+
+      it('should not yoyo all groups', async () => {
+        const groups = await loadAnimation({
+          yoyo: false,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].yoyo())).to.deep.equal([false, false, false])
+      })
+
+    })
+
+    describe('delay', () => {
+
+      it('should not delay single group', async () => {
+        const timeline = await loadAnimation({ animationData: createSimpleGroup('a', 'div[1]') })
+        expect(timeline.delay()).to.equal(0)
+      })
+
+      it('should delay single group', async () => {
+        const timeline = await loadAnimation({
+          delay: 2,
+          animationData: createSimpleGroup('a', 'div[1]')
+        })
+        expect(timeline.delay()).to.equal(2)
+      })
+
+      it('should delay all groups', async () => {
+        const groups = await loadAnimation({
+          delay: 2,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].delay())).to.deep.equal([2, 2, 2])
+      })
+
+      it('should not delay all groups', async () => {
+        const groups = await loadAnimation({
+          delay: 0,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]'),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].delay())).to.deep.equal([0, 0, 0])
+      })
+
+    })
+
+    describe('time scale', () => {
+
+      it('should not overwrite time scale for single group', async () => {
+        const timeline = await loadAnimation({ animationData: createSimpleGroup('a', 'div[1]') })
+        expect(timeline.timeScale()).to.equal(1)
+      })
+
+      it('should overwrite time scale for single group', async () => {
+        const timeline = await loadAnimation({
+          timeScale: 5,
+          animationData: createSimpleGroup('a', 'div[1]')
+        })
+        expect(timeline.timeScale()).to.equal(5)
+      })
+
+      it('should overwrite time scale for all groups', async () => {
+        const groups = await loadAnimation({
+          timeScale: 4,
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]'),
+            createSimpleGroup('b', 'div[1]/div[2]', { timeScale: 2 }),
+            createSimpleGroup('c', 'div[1]/div[3]')
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].timeScale())).to.deep.equal([4, 4, 4])
+      })
+
+      it('should not overwrite time scale for all groups', async () => {
+        const groups = await loadAnimation({
+          animationData: [
+            createSimpleGroup('a', 'div[1]/div[1]', { timeScale: 1.2 }),
+            createSimpleGroup('b', 'div[1]/div[2]', { timeScale: 2 }),
+            createSimpleGroup('c', 'div[1]/div[3]', { timeScale: 2.2 })
+          ]
+        })
+        expect(Object.keys(groups).map(g => groups[g].timeScale())).to.deep.equal([1.2, 2, 2.2])
+      })
+
+    })
+
+  })
+
+})

--- a/wallaby.config.js
+++ b/wallaby.config.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// use babel modules
+process.env.BABEL_ENV = 'modules'
+
 module.exports = function(wallaby) {
 
   return {


### PR DESCRIPTION
# Add shorthand version for animation playback

## Signature

```es6
spirit.loadAnimation(data: object): Promise<Timeline|object>
```
## Playback

Play animation data (copied from app):

```es6
spirit.loadAnimation({
  animationData: { ... }
})
```

Play animation from url:

```es6
spirit.loadAnimation({
  path: 'animation.json'
})
```

Add playback features:

```es6
spirit.loadAnimation({
  loop: true,
  yoyo: true,
  delay: 1,
  path: 'animation.json'
})
```

## Supported features:

```yaml
animationData          : object              object with the exported animation data
path                   : string              the path to the animation json
loop                   : true|false|number   (default = false)
delay                  : number              (default = 0)
yoyo                   : number              (default = false) play back and forth
timescale              : number              overwrite timescales
autoPlay               : true|false          (default = true) play as soon as it is ready
```

## Return values

**Load a single group:** 

```ts
spirit.loadAnimation(data: object): Promise<Timeline>
```

example:

```es6
spirit.loadAnimation({ autoPlay: false, path: 'single-group.json' }).then(timeline => {
  timeline.reverse().play()
})
```

**Load multiple groups**

```ts
spirit.loadAnimation(data: object): Promise<object>
```

example (with groups: `chair` and `table`):

```es6
spirit.loadAnimation({ autoPlay: false, path: 'multiple-groups.json' }).then(groups => {
  groups['chair'].construct().play()
  groups['table'].construct().reverse().play()
})
```