### PR TITLE
Make ie11 compatible

### DIFF
--- a/src/data/parser.js
+++ b/src/data/parser.js
@@ -103,7 +103,8 @@ function groupsFactory() {
   let list = []
 
   const getGroupsByRoot = function(root) {
-    for (let groups of list) {
+    for (let i = 0; i < list.length; i++) {
+      let groups = list[i]
       if (groups.rootEl === root) {
         return groups
       }

--- a/src/group/prop.js
+++ b/src/group/prop.js
@@ -2,6 +2,7 @@ import Keyframes from './keyframes'
 import { is, events } from '../utils'
 import { emitChange } from '../utils/emitter'
 import { Emitter } from '../utils/events'
+import { includes } from '../utils/polyfill'
 
 /**
  * -------------------------------------------
@@ -159,12 +160,12 @@ class Prop extends Emitter {
    * @returns {boolean}
    */
   isCSSTransform() {
-    return [
+    return includes([
       'x', 'y', 'z',
       'rotation', 'rotationZ', 'rotationX', 'rotationY',
       'skewX', 'skewY',
       'scale', 'scaleX', 'scaleY'
-    ].includes(this.name)
+    ], this.name)
   }
 
   /**

--- a/src/group/timeline.js
+++ b/src/group/timeline.js
@@ -1,5 +1,6 @@
 import Props from './props'
 import { context, convert, is } from '../utils'
+import { includes } from '../utils/polyfill'
 import EvalMap from './evalmap'
 
 /**
@@ -130,7 +131,7 @@ Timeline.fromObject = function(obj) {
 
   const keys = Object.keys(obj)
 
-  if (!keys.includes('transformObject')) {
+  if (!includes(keys, 'transformObject')) {
     throw new Error('Object is invalid')
   }
 

--- a/src/loadAnimation.js
+++ b/src/loadAnimation.js
@@ -80,22 +80,24 @@ export default function(manifest) {
 
         // multiple groups!
         let g = {}
-        for (let groups of result) {
-          for (let group of groups) {
+        result.forEach(groups => {
+          groups.each(group => {
             g[group.name] = group.construct()
             g[group.name].construct = function() {
               let tl = registry.get(group.name).construct()
               tl.construct = this.construct
               return tl
             }
-          }
-        }
+          })
+        })
         return g
       })
       .then(res => {
         let timelines = (res instanceof config.gsap.timeline) ? [res] : Object.keys(res).map(k => res[k])
 
-        for (let timeline of timelines) {
+        for (let i = 0; i < timelines.length; i++) {
+          let timeline = timelines[i]
+
           if (options.loop) {
             timeline.repeat(options.loop)
           }

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -1,6 +1,7 @@
 import List from '../list/list'
 import { Group } from '../group'
 import { debug } from '../utils'
+import { includes } from '../utils/polyfill'
 
 class Registry extends List {
 
@@ -18,7 +19,7 @@ class Registry extends List {
       throw new Error('Invalid group. Only Group instances allowed.')
     }
 
-    if (!this.groupNames().includes(group.name)) {
+    if (!includes(this.groupNames(), group.name)) {
       if (debug()) {
         console.warn(`registry.add() Group "${group.name}" added to registry (spirit.groups) and can be resolved by Spirit app`)
       }

--- a/src/utils/autobind.js
+++ b/src/utils/autobind.js
@@ -1,3 +1,5 @@
+import { includes } from './polyfill'
+
 export default function(...args) {
   return (args.length === 1)
     ? boundClass(...args)
@@ -13,7 +15,7 @@ function boundClass(target) {
   }
 
   keys.forEach(key => {
-    if (ignoreMethods.includes(key)) {
+    if (includes(ignoreMethods, key)) {
       return
     }
 

--- a/src/utils/polyfill.js
+++ b/src/utils/polyfill.js
@@ -1,0 +1,8 @@
+export function includes(arr, item) {
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i] === item) {
+      return true
+    }
+  }
+  return false
+}

--- a/src/utils/proxify.js
+++ b/src/utils/proxify.js
@@ -1,4 +1,8 @@
 export function ArrayLike(targetClass, list) {
+  if (!('Proxy' in window)) {
+    return targetClass
+  }
+
   return class extends targetClass {
 
     static get name() { return targetClass.name }

--- a/src/utils/xpath.js
+++ b/src/utils/xpath.js
@@ -1,10 +1,11 @@
 import { isSVG } from './is'
+import debug from './debug'
 
 /**
  * Get DOM representation for an element.
  *
- * @param   {Element}                     element
- * @param   {null|undefined|HTMLElement}  nodeContext
+ * @param   {Element}              element
+ * @param   {null|undefined|Node}  nodeContext
  * @returns {string|null}
  */
 export function getExpression(element, nodeContext = null) {
@@ -49,15 +50,24 @@ export function getExpression(element, nodeContext = null) {
 /**
  * Get an element from expression
  *
- * @param {string}      expression
- * @param {HTMLElement} nodeContext
- * @returns {HTMLElement|null}
+ * @param   {string} expression
+ * @param   {Node}   nodeContext
+ * @returns {Node|null}
  */
 export function getElement(expression, nodeContext = null) {
   if (!nodeContext) {
     nodeContext = document.body
   }
 
-  const evaluated = document.evaluate(expression, nodeContext, null, window.XPathResult.ANY_TYPE, null)
-  return evaluated.iterateNext()
+  try {
+    const evaluated = document.evaluate(expression, nodeContext, null, window.XPathResult.ANY_TYPE, null)
+    return evaluated.iterateNext()
+  } catch (err) {
+    if (debug()) {
+      console.error('Cannot get element from expression: ', expression)
+      console.error(err.stack)
+    }
+  }
+
+  return null
 }


### PR DESCRIPTION
Create workarounds for:

- Symbol.iterator
- Proxy object
- Xpath
- Array.includes

as they are, not −or not fully− implemented in IE11.

Required features are only `es6`:

```html
<script src="https://cdn.polyfill.io/v2/polyfill.js?features=es6&flags=gated"></script>
```