### PR TITLE
Resolve elements during runtime

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,6 +1,9 @@
+import { isBrowser } from '../utils/context'
+
 class Config {
 
-  debug = true
+  debug = process.env.NODE_ENV === 'development' && isBrowser()
+  overwriteAnimations = true
 
   gsap = {
     tween: null,

--- a/src/config/setup.js
+++ b/src/config/setup.js
@@ -1,41 +1,23 @@
 import { gsap, is } from '../utils'
 import config from './config'
-import debug from '../utils/debug'
-
-const version = require('../../package.json').version
 
 /**
  * Setup Spirit GSAP
  *
  * @param {object} conf
  */
-export default function setup(conf) {
+export default function setup(conf = {}) {
   return new Promise((resolve, reject) => {
-    let timeline, tween
+    is.isObject(conf) && Object.keys(conf).forEach(k => {
+      let obj = (config.gsap.hasOwnProperty(k) && is.isFunction(conf[k]))
+        ? config.gsap
+        : config
 
-    if (is.isObject(conf)) {
-      if (typeof conf.timeline === 'function' && typeof conf.tween === 'function') {
-        timeline = conf.timeline
-        tween = conf.tween
-      }
+      obj[k] = conf[k]
+    })
 
-      if (typeof conf.debug === 'boolean') {
-        config.debug = conf.debug
-      }
-    }
-
-    if (debug()) {
-      console.warn(`You are running the development build of Spirit v${version}.`)
-    }
-
-    if (!tween || !timeline) {
-      gsap.ensure()
-        .then(resolve)
-        .catch(reject)
-    } else {
-      config.gsap.tween = tween
-      config.gsap.timeline = timeline
-      resolve()
-    }
+    gsap.ensure()
+      .then(resolve)
+      .catch(reject)
   })
 }

--- a/src/group/group.js
+++ b/src/group/group.js
@@ -17,13 +17,6 @@ class Group extends Emitter {
   timeline = null
 
   /**
-   * Unresolved timelines
-   *
-   * @type {Array}
-   */
-  unresolved = []
-
-  /**
    * Create a group instance.
    *
    * @param {object} props
@@ -54,6 +47,28 @@ class Group extends Emitter {
    */
   get timelines() {
     return this._timelines
+  }
+
+  /**
+   * Get unresolved timelines
+   *
+   * @returns {Timelines}
+   */
+  get unresolved() {
+    let timelines = new Timelines()
+    this.timelines.each(tl => !tl.transformObject && timelines.add(tl))
+    return timelines
+  }
+
+  /**
+   * Get resolved timelines
+   *
+   * @returns {Timelines}
+   */
+  get resolved() {
+    let timelines = new Timelines()
+    this.timelines.each(tl => !!tl.transformObject && timelines.add(tl))
+    return timelines
   }
 
   /**

--- a/src/group/groups.js
+++ b/src/group/groups.js
@@ -1,7 +1,6 @@
 import List from '../list/list'
 import Group from './group'
-import config from '../config/config'
-import { debug } from '../utils'
+import { debug, gsap } from '../utils'
 import registry from '../registry/registry'
 
 class Groups extends List {
@@ -64,25 +63,8 @@ class Groups extends List {
    * @returns {Array.<TimelineLite|TimelineMax>}
    */
   construct() {
-    if (!config.gsap.timeline || !config.gsap.tween) {
-      if (debug()) {
-        console.warn(`
-            Trying to construct groups, but GSAP cannot be found.
-            
-            Did you forgot to call spirit.setup() ?
-            
-            spirit.setup() usage:
-            
-                // auto inject gsap from cdn:
-                spirit.setup()
-                
-                // or provide gsap instances manually:
-                spirit.setup({
-                  tween:    TweenMax,
-                  timeline: TimelineMax
-                })
-          `)
-      }
+    if (!gsap.has()) {
+      debug() && console.warn('Trying to construct groups, but GSAP cannot be found.')
       throw new Error('GSAP cannot be found')
     }
     return this.list.map(group => group.construct())

--- a/src/group/timeline.js
+++ b/src/group/timeline.js
@@ -84,6 +84,14 @@ class Timeline extends Emitter {
     this._transformObject = transformObject
     this.validate()
 
+    if (transformObject && this.props instanceof Props) {
+      const thisMapper = this.props.mappings.find(mapping => String(mapping.regex) === '/this/g')
+
+      thisMapper
+        ? (thisMapper.map = transformObject)
+        : this.props.mappings.push(new EvalMap(/this/g, transformObject))
+
+      this.props.mappings = [...this.props.mappings]
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import setup from './config/setup'
 import groups from './registry/registry'
 import { create, load } from './data/parser'
 import loadAnimation from './loadAnimation'
+import debug from './utils/debug'
 
 const Spirit = function() {}
 
@@ -36,4 +37,8 @@ module.exports = spirit
 
 if (context.isBrowser() && !window.spirit) {
   window.spirit = spirit
+
+  if (debug()) {
+    console.warn(`You are running the development build of Spirit v${version}.`)
+  }
 }

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -41,6 +41,16 @@ class Registry extends List {
 
     warn('skipped, already exists in registry')
   }
+
+  /**
+   * Remove group from registry
+   *
+   * @param   {Group} group
+   * @returns {Group}
+   */
+  remove(group) {
+    group.reset()
+    return super.remove(group)
   }
 
   /**

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -1,7 +1,7 @@
 import List from '../list/list'
 import { Group } from '../group'
 import { debug } from '../utils'
-import { includes } from '../utils/polyfill'
+import config from '../config/config'
 
 class Registry extends List {
 
@@ -19,16 +19,28 @@ class Registry extends List {
       throw new Error('Invalid group. Only Group instances allowed.')
     }
 
-    if (!includes(this.groupNames(), group.name)) {
-      if (debug()) {
-        console.warn(`registry.add() Group "${group.name}" added to registry (spirit.groups) and can be resolved by Spirit app`)
+    const existingGroup = this.get(group.name)
+    const warn = msg => debug() && console.warn(`registry.add() Group "${group.name}" ${msg}`)
+
+    const addToRegistry = () => {
+      if (existingGroup) {
+        warn('overwrite group in registry')
+        this.remove(existingGroup)
       }
       super.add(group)
-    } else {
-      if (debug()) {
-        console.warn(`registry.add() Group "${group.name}" already exist in registry. Skip registry (spirit.groups)`)
-      }
     }
+
+    if (config.overwriteAnimations) {
+      return addToRegistry()
+    }
+
+    if (!existingGroup) {
+      warn('added to registry and can be resolved by Spirit desktop app')
+      return addToRegistry()
+    }
+
+    warn('skipped, already exists in registry')
+  }
   }
 
   /**

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -1,5 +1,5 @@
 import { isBrowser } from './context'
 import config from '../config/config'
 
-const debug = () => process.env.NODE_ENV === 'development' && isBrowser() && Boolean(config.debug)
+const debug = () => isBrowser() && Boolean(config.debug)
 export default debug

--- a/src/utils/gsap.js
+++ b/src/utils/gsap.js
@@ -135,12 +135,12 @@ export function generateTimeline(timeline) {
     throw new Error('Need valid timeline data to generate GSAP timeline from')
   }
 
-  if (!config.gsap.timeline) {
-    throw new Error('GSAP not set. Please make sure GSAP is available.')
-  }
-
   if (timeline.type !== 'dom') {
     throw new Error('Timeline invalid. Needs a timeline with type of dom.')
+  }
+
+  if (!has()) {
+    throw new Error('GSAP not set. Please make sure GSAP is available.')
   }
 
   const tl = new config.gsap.timeline({ paused: true }) // eslint-disable-line new-cap
@@ -210,7 +210,7 @@ export function generateTimeline(timeline) {
  * @param {TimelineMax|TimelineLite} gsapTimeline
  */
 export function killTimeline(gsapTimeline) {
-  if (gsapTimeline && isFunction(config.gsap.timeline) && gsapTimeline instanceof config.gsap.timeline) {
+  if (isTimeline(gsapTimeline)) {
     gsapTimeline.eventCallback('onComplete', null)
     gsapTimeline.eventCallback('onUpdate', null)
     gsapTimeline.eventCallback('onStart', null)
@@ -219,7 +219,7 @@ export function killTimeline(gsapTimeline) {
     gsapTimeline.kill()
 
     for (let i = 0; i < targets.length; i++) {
-      if (targets[i] && targets[i] instanceof config.gsap.timeline) {
+      if (isTimeline(targets[i])) {
         killTimeline(targets[i])
         continue
       }
@@ -230,4 +230,14 @@ export function killTimeline(gsapTimeline) {
     }
     gsapTimeline.clear()
   }
+
+  return gsapTimeline
+}
+
+export function isTimeline(timeline) {
+  return timeline && isFunction(config.gsap.timeline) && timeline instanceof config.gsap.timeline
+}
+
+export function isTween(tween) {
+  return tween && isFunction(config.gsap.tween) && tween instanceof config.gsap.tween
 }

--- a/src/utils/gsap.js
+++ b/src/utils/gsap.js
@@ -210,7 +210,7 @@ export function generateTimeline(timeline) {
  * @param {TimelineMax|TimelineLite} gsapTimeline
  */
 export function killTimeline(gsapTimeline) {
-  if (gsapTimeline && gsapTimeline instanceof config.gsap.timeline) {
+  if (gsapTimeline && isFunction(config.gsap.timeline) && gsapTimeline instanceof config.gsap.timeline) {
     gsapTimeline.eventCallback('onComplete', null)
     gsapTimeline.eventCallback('onUpdate', null)
     gsapTimeline.eventCallback('onStart', null)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,7 @@ import * as convert from './convert'
 import * as xpath from './xpath'
 import * as is from './is'
 import * as emitter from './emitter'
+import * as resolver from './resolver'
 import loadscript from './loadscript'
 import jsonloader from './jsonloader'
 import autobind from './autobind'
@@ -21,5 +22,6 @@ export {
   loadscript,
   jsonloader,
   autobind,
-  debug
+  debug,
+  resolver
 }

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -1,0 +1,36 @@
+import debug from './debug'
+import * as xpath from './xpath'
+
+/**
+ * Resolve element relative to root
+ *
+ * @param {Element}       root
+ * @param {{ path, id }}  data
+ * @param {boolean}       throwException
+ */
+export function resolveElement(root, data, throwException = false) {
+  let transformObject = null
+  let { path, id } = data
+
+  if (id) {
+    transformObject = root.querySelector(`[data-spirit-id="${id}"]`)
+  }
+
+  if (!transformObject && path) {
+    transformObject = xpath.getElement(path, root === document.body ? undefined : root)
+  }
+
+  if (!transformObject) {
+    if (debug()) {
+      console.group('Unable to resolve element')
+      console.warn('Timeline: ', data)
+      console.groupEnd()
+    }
+
+    if (throwException) {
+      throw new Error('Cannot find element.')
+    }
+  }
+
+  return transformObject
+}

--- a/src/utils/xpath.js
+++ b/src/utils/xpath.js
@@ -56,7 +56,7 @@ export function getExpression(element, nodeContext = null) {
  */
 export function getElement(expression, nodeContext = null) {
   if (!nodeContext) {
-    nodeContext = document.body
+    nodeContext = document.body || document.documentElement
   }
 
   try {

--- a/test/config-spec.js
+++ b/test/config-spec.js
@@ -6,36 +6,51 @@ const configGsap = { ...config.gsap }
 
 describe('config', () => {
 
+  let sandbox
+
   beforeEach(() => {
     config.gsap.autoInjectUrl = 'test/fixtures/gsap.js'
-    sinon.spy(gsap, 'ensure')
+
+    sandbox = sinon.sandbox.create()
+    sandbox.spy(gsap, 'ensure')
+    sandbox.spy(gsap, 'loadFromCDN')
   })
 
   afterEach(() => {
+    sandbox.restore()
     config.gsap = { ...configGsap }
-    gsap.ensure.restore()
+
+    delete window.TweenMax
+    delete window.TweenLite
+    delete window.TimelineMax
+    delete window.TimelineLite
   })
 
-  it('should ensure gsap when no gsap instances are provided', async () => {
+  it('should load gsap from CDN on setup()', async () => {
     expect(config).to.have.deep.property('gsap.tween', null)
     expect(config).to.have.deep.property('gsap.timeline', null)
     expect(gsap.ensure.callCount).to.equal(0)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
 
     await setup()
 
     expect(gsap.ensure.callCount).to.equal(1)
+    expect(gsap.loadFromCDN.callCount).to.equal(1)
+
     expect(config).to.have.deep.property('gsap.tween').to.be.a('function')
     expect(config).to.have.deep.property('gsap.timeline').to.be.a('function')
   })
 
-  it('should ensure gsap when invalid gsap instances are provided', async () => {
+  it('should load gsap from CDN on invalid gsap params', async () => {
     expect(config).to.have.deep.property('gsap.tween', null)
     expect(config).to.have.deep.property('gsap.timeline', null)
     expect(gsap.ensure.callCount).to.equal(0)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
 
     await setup({ timeline: 123, tween: 123 })
 
     expect(gsap.ensure.callCount).to.equal(1)
+    expect(gsap.loadFromCDN.callCount).to.equal(1)
     expect(config).to.have.deep.property('gsap.tween').to.be.a('function')
     expect(config).to.have.deep.property('gsap.timeline').to.be.a('function')
   })
@@ -44,13 +59,46 @@ describe('config', () => {
     expect(config).to.have.deep.property('gsap.tween', null)
     expect(config).to.have.deep.property('gsap.timeline', null)
     expect(gsap.ensure.callCount).to.equal(0)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
 
-    await setup({
-      timeline: () => {},
-      tween: () => {}
-    })
+    await setup({ timeline: () => {}, tween: () => {} })
 
+    expect(gsap.ensure.callCount).to.equal(1)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
+    expect(config).to.have.deep.property('gsap.tween').to.be.a('function')
+    expect(config).to.have.deep.property('gsap.timeline').to.be.a('function')
+  })
+
+  it('should setup gsap from window object (using *Max)', async () => {
+    window.TweenMax = () => {}
+    window.TimelineMax = () => {}
+
+    expect(config).to.have.deep.property('gsap.tween', null)
+    expect(config).to.have.deep.property('gsap.timeline', null)
     expect(gsap.ensure.callCount).to.equal(0)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
+
+    await setup()
+
+    expect(gsap.ensure.callCount).to.equal(1)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
+    expect(config).to.have.deep.property('gsap.tween').to.be.a('function')
+    expect(config).to.have.deep.property('gsap.timeline').to.be.a('function')
+  })
+
+  it('should setup gsap from window object (using *Lite)', async () => {
+    window.TweenLite = () => {}
+    window.TimelineLite = () => {}
+
+    expect(config).to.have.deep.property('gsap.tween', null)
+    expect(config).to.have.deep.property('gsap.timeline', null)
+    expect(gsap.ensure.callCount).to.equal(0)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
+
+    await setup()
+
+    expect(gsap.ensure.callCount).to.equal(1)
+    expect(gsap.loadFromCDN.callCount).to.equal(0)
     expect(config).to.have.deep.property('gsap.tween').to.be.a('function')
     expect(config).to.have.deep.property('gsap.timeline').to.be.a('function')
   })

--- a/test/fixtures/group/groups.js
+++ b/test/fixtures/group/groups.js
@@ -11,7 +11,7 @@ export const simpleGroups = [
       {
         label: 'head',
         transformObject: divA,
-        path: 'div[0]',
+        path: 'div[1]',
         props: {
           x: { '0s': { value: 0 }, '10s': { value: 300 } },
           y: { '0s': { value: 0 }, '10s': { value: 1000 } }
@@ -20,7 +20,7 @@ export const simpleGroups = [
       {
         label: 'body',
         transformObject: divB,
-        path: 'div[1]',
+        path: 'div[2]',
         props: {
           scale: { '10s': { value: 2 } }
         }

--- a/test/parser-spec.js
+++ b/test/parser-spec.js
@@ -86,42 +86,22 @@ describe('parser', () => {
     describe('unresolved elements', () => {
       it('should fail to resolve element with id only', () => {
         group.timelines = [{ id: 'ghost', label: 'logo' }]
-
-        const result = create(group)
-        expect(result.at(0).unresolved).to.have.lengthOf(1)
-        expect(result.at(0).unresolved)
-          .to.have.deep.property('[0].error')
-          .to.match(/Cannot find element with \[data-spirit-id="ghost"/)
+        expect(create(group).at(0).unresolved).to.have.lengthOf(1)
       })
 
       it('should fail to resolve element with path only', () => {
         group.timelines = [{ path: 'div[1]/h1[1]', logo: 'logo' }]
-
-        const result = create(group)
-        expect(result.at(0).unresolved).to.have.lengthOf(1)
-        expect(result.at(0).unresolved)
-          .to.have.deep.property('[0].error')
-          .to.match(/Cannot find element with path expression div\[1]\/h1\[1]/)
+        expect(create(group).at(0).unresolved).to.have.lengthOf(1)
       })
 
       it('should fail to resolve element with id and path', () => {
         group.timelines = [{ id: 'ghost', path: 'div[2]/p[2]' }]
-
-        const result = create(group)
-        expect(result.at(0).unresolved).to.have.lengthOf(1)
-        expect(result.at(0).unresolved)
-          .to.have.deep.property('[0].error')
-          .to.match(/Cannot find element with path expression div\[2]\/p\[2]/)
+        expect(create(group).at(0).unresolved).to.have.lengthOf(1)
       })
 
       it('should fail to resolve if id and path are not set', () => {
         group.timelines = [{ label: 'logo' }]
-
-        const result = create(group)
-        expect(result.at(0).unresolved).to.have.lengthOf(1)
-        expect(result.at(0).unresolved)
-          .to.have.deep.property('[0].error')
-          .to.match(/Cannot find element/)
+        expect(create(group).at(0).unresolved).to.have.lengthOf(1)
       })
     })
 
@@ -344,7 +324,7 @@ describe('parser', () => {
       expect(cache[url]).to.deep.equal(JSON.parse(jsonGhost))
     })
 
-    it('should store unresolved timelines with errors', async () => {
+    it('should store unresolved timelines', async () => {
       stubXhr(sandbox, { responseText: jsonGhost })
 
       const result = await load('animation.json')
@@ -352,23 +332,12 @@ describe('parser', () => {
 
       const g = result.at(0)
 
-      expect(g.timelines).to.have.lengthOf(0)
+      expect(g.timelines).to.have.lengthOf(4)
+      expect(g.resolved).to.have.lengthOf(0)
       expect(g.unresolved).to.have.lengthOf(4)
-
-      let matchers = [
-        /Cannot find element with path expression svg\[1]/,
-        /Cannot find element with path expression svg\[1]\/path\[1]/,
-        /Cannot find element with \[data-spirit-id="eyes"]/,
-        /Cannot find element with path expression svg\[1]\/path\[2]/
-      ]
-
-      matchers.forEach((matcher, i) => {
-        expect(g.unresolved[i].error).to.match(matcher)
-      })
     })
 
     describe('parse', () => {
-
       let gc
 
       beforeEach(() => {

--- a/test/registry-spec.js
+++ b/test/registry-spec.js
@@ -1,11 +1,16 @@
 import { create } from '../src'
 import registry from '../src/registry/registry'
 import { Group } from '../src/group'
+import config from '../src/config/config'
 
 describe('registry', () => {
 
   beforeEach(() => {
     registry.clear()
+  })
+
+  afterEach(() => {
+    config.overwriteAnimations = true
   })
 
   it('should have an empty registry', () => {
@@ -45,19 +50,32 @@ describe('registry', () => {
     expect(registry.groupNames()).to.deep.equal(['ghost', 'logo'])
   })
 
-  it('should skip existing group', () => {
+  it('should skip existing group with config.overwriteAnimations false', () => {
+    config.overwriteAnimations = false
+
     create([
       { name: 'ghost', timelines: [] },
       { name: 'logo', timelines: [] }
     ])
 
     const ghost = registry.get('ghost')
-    const logo = registry.get('logo')
-
     const created = create({ name: 'ghost', timelines: [] }).at(0)
 
     expect(registry.get('ghost')).to.equal(ghost)
     expect(registry.get('ghost')).not.to.equal(created)
+  })
+
+  it('should overwrite existing group with config.overwriteAnimations true', () => {
+    create([
+      { name: 'ghost', timelines: [] },
+      { name: 'logo', timelines: [] }
+    ])
+
+    const ghost = registry.get('ghost')
+    const created = create({ name: 'ghost', timelines: [] }).at(0)
+
+    expect(registry.get('ghost')).to.equal(created)
+    expect(registry.get('ghost')).not.to.equal(ghost)
   })
 
   describe('add and remove from groups', () => {
@@ -138,7 +156,7 @@ describe('registry', () => {
       expect(registry.groupNames()).to.deep.equal(['a', 'b', 'c', 'd', 'e'])
       expect(registry.get('a')).to.equal(a.get('a'))
       expect(registry.get('b')).to.equal(a.get('b'))
-      expect(registry.get('c')).to.equal(a.get('c'))
+      expect(registry.get('c')).to.equal(b.get('c'))
       expect(registry.get('d')).to.equal(b.get('d'))
       expect(registry.get('e')).to.equal(b.get('e'))
     })

--- a/test/registry-spec.js
+++ b/test/registry-spec.js
@@ -137,6 +137,29 @@ describe('registry', () => {
       expect(registry).to.have.lengthOf(0)
     })
 
+    it('should call reset for removed group', () => {
+      const group = groups.add({ name: 'a' })
+      sinon.spy(group, 'reset')
+
+      groups.remove(group)
+      expect(group.reset.called).to.be.true
+      group.reset.restore()
+    })
+
+    it('should call reset for removed groups on clear', () => {
+      const created = groups.add([
+        { name: 'a' },
+        { name: 'b' },
+        { name: 'c' }
+      ])
+
+      groups.each(g => sinon.spy(g, 'reset'))
+      groups.clear()
+
+      expect(created.map(g => g.reset.called)).to.deep.equal([true, true, true])
+      created.forEach(g => g.reset.restore())
+    })
+
   })
 
   describe('multi groups', () => {

--- a/test/timeline-spec.js
+++ b/test/timeline-spec.js
@@ -9,17 +9,9 @@ describe('timeline', () => {
     el = document.createElement('div')
   })
 
-  describe('type is DOM element', () => {
-    it('should require an html element', () => {
-      expect(() => new Timeline()).to.throw(/transformObject needs to be an element/)
-    })
-
-    it('should require path', () => {
-      expect(() => new Timeline('dom', el)).to.throw(/path is not defined/)
-    })
-
-    it('should not require path if id is set', async () => {
-      expect(() => new Timeline('dom', el, [], null, 'my-id')).to.not.throw(/path is not defined/)
+  describe('type is Element', () => {
+    it('should allow nullable element', () => {
+      expect(() => new Timeline()).not.to.throw(/transformObject needs to be an element/)
     })
 
     it('should have element and props defined', () => {
@@ -54,8 +46,8 @@ describe('timeline', () => {
   })
 
   describe('type is Object', () => {
-    it('should require an transform object', async () => {
-      expect(() => new Timeline('object')).to.throw(/transformObject needs to be an object/)
+    it('should allow nullable transform object', async () => {
+      expect(() => new Timeline('object')).not.to.throw(/transformObject needs to be an object/)
     })
 
     it('should not require any additional arguments', () => {
@@ -134,31 +126,57 @@ describe('timeline', () => {
     })
   })
 
+  describe('validate', () => {
+    it('should validate element', () => {
+      const tl = new Timeline('dom')
+
+      expect(() => tl.validate()).not.to.throw()
+      expect(() => {tl.transformObject = 123}).to.throw(/transformObject needs to be an element/)
+      expect(() => {tl.transformObject = null}).not.to.throw()
+      expect(() => {tl.transformObject = document.createElement('div')}).not.to.throw()
+    })
+
+    it('should validate object', () => {
+      const tl = new Timeline('object')
+
+      expect(() => tl.validate()).not.to.throw()
+      expect(() => {tl.transformObject = 123}).to.throw(/transformObject needs to be an object/)
+      expect(() => {tl.transformObject = null}).not.to.throw()
+      expect(() => {tl.transformObject = {}}).not.to.throw()
+    })
+  })
+
   describe('parse fromObject', () => {
     it('should fail with invalid type', () => {
       expect(() => Timeline.fromObject(123)).to.throw(/Object is invalid/)
       expect(() => Timeline.fromObject([])).to.throw(/Object is invalid/)
     })
 
-    it('should fail when no transformObject is provided', () => {
-      expect(() => Timeline.fromObject({})).to.throw(/Object is invalid/)
+    it('should be able to parse a timeline without a transform object', () => {
+      expect(() => Timeline.fromObject({})).not.to.throw()
     })
 
     describe('as dom', () => {
       it('should fail if transformObject is not a HTMLElement', () => {
-        expect(() => Timeline.fromObject({ transformObject: 123 })).to.throw(/transformObject needs to be an element/)
+        const fn = () => Timeline.fromObject({ type: 'dom', transformObject: 123 })
+        expect(fn).to.throw(/transformObject needs to be an element/)
       })
 
       it('should create a valid timeline', () => {
-        expect(() => Timeline.fromObject({ transformObject: el, path: 'div[0]' })).to.not.throw(Error)
+        const fn = () => Timeline.fromObject({ transformObject: el, path: 'div[0]' })
+        expect(fn).to.not.throw(Error)
       })
     })
 
     describe('as object', () => {
+      it('should fail if transformObject is not an object', () => {
+        const fn = () => Timeline.fromObject({ type: 'object', transformObject: 123 })
+        expect(fn).to.throw(/transformObject needs to be an object/)
+      })
+
       it('should create a timeline with transformObject as object', () => {
-        expect(() => {
-          Timeline.fromObject({ type: 'object', transformObject: { a: 'a', b: 'b' } })
-        }).not.to.throw(Error)
+        const fn = () => Timeline.fromObject({ type: 'object', transformObject: { a: 'a', b: 'b' } })
+        expect(fn).not.to.throw(Error)
       })
 
       it('should create a timeline with properties', () => {
@@ -311,6 +329,31 @@ describe('timeline', () => {
       prop.keyframes.get(0).value = 20
       expect(spy.callCount).to.equal(1)
     })
+  })
+
+  describe('dispatch events', () => {
+
+    it('should dispatch change:transformObject', () => {
+      let spy = sinon.spy()
+      let tl = new Timeline('dom')
+
+      expect(tl).to.have.property('transformObject', null)
+
+      tl.on('change', spy)
+      tl.on('change:transformObject', spy)
+
+      const el = document.createElement('div')
+      tl.transformObject = el
+
+      expect(spy.calledTwice).to.be.true
+      expect(spy.getCall(0).args[0].changed).to.deep.equal({
+        type: 'transformObject',
+        from: null,
+        to: el
+      })
+      tl.removeAllListeners()
+    })
+
   })
 
 })

--- a/test/timeline-spec.js
+++ b/test/timeline-spec.js
@@ -288,6 +288,30 @@ describe('timeline', () => {
         expect(keyframe).to.have.property('mappings').to.have.lengthOf(1)
       })
 
+      it('should reapply mappings when transform object changes', () => {
+        const elA = document.createElement('div')
+        const elB = document.createElement('div')
+
+        elA.setAttribute('data-speed', 10)
+        elB.setAttribute('data-speed', 20)
+
+        const tl = new Timeline('dom', elA, {
+          x: {
+            '0s': `{ parseInt(this.getAttribute('data-speed')) }`
+          }
+        })
+
+        expect(tl.props.mappings).to.have.lengthOf(1)
+        expect(tl.props.mappings).to.have.deep.property('[0].map', elA)
+        expect(tl.props.get('x').keyframes.get(0)).to.have.property('value', 10)
+
+        tl.transformObject = elB
+
+        expect(tl.props.mappings).to.have.lengthOf(1)
+        expect(tl.props.mappings).to.have.deep.property('[0].map', elB)
+        expect(tl.props.get('x').keyframes.get(0)).to.have.property('value', 20)
+      })
+
     })
 
     describe('as dom', () => {

--- a/test/utils-spec.js
+++ b/test/utils-spec.js
@@ -132,6 +132,11 @@ describe('utils', () => {
 
     afterEach(() => {
       config.gsap = { ...gsapConfig }
+
+      delete window.TweenMax
+      delete window.TweenLite
+      delete window.TimelineMax
+      delete window.TimelineLite
     })
 
     describe('ensure', () => {


### PR DESCRIPTION
### Related issue: #20 

### Description

**Element resolving**

Elements can be removed/added to the document object model during runtime. Ideally, element resolving should take place on request. 

Currently, elements are getting resolved at creation only: `spirit.create()` and `spirit.load()`. The reason is simple 👉  resolving elements is expensive, doing this each time you call a playback method is killing the performance. 
However, there are workarounds to fix this issue, which I try to address in this PR.

**Debug support**

Force debug messages using `spirit.config.debug`.

**Resolve GSAP from window**

Before loading GSAP from CDN, try to resolve it from the window object first.

**Overwrite groups**

Group names are unique, loading an animation group that already exists is simple ignored. The default behaviour should be overwriting instead. Make the overwrite behaviour configurable via `sprit.config.overwriteAnimations`.

- [x] Resolve elements during runtime
- [x] Better debugging support
- [x] Resolve GSAP from window object
- [x] Overwrite groups
