### PR TITLE
Reset DOM styles

### DIFF
--- a/src/group/group.js
+++ b/src/group/group.js
@@ -172,9 +172,19 @@ class Group extends Emitter {
   }
 
   reset() {
+    let killed = false
     if (this.timeline) {
+      killed = true
       gsap.killTimeline(this.timeline)
+
+      // reset styles
+      this.timelines.each(tl => {
+        if (tl.type === 'dom' && tl.transformObject instanceof window.Element) {
+          tl._style && tl.transformObject.setAttribute('style', tl._style)
+        }
+      })
     }
+    return killed
   }
 
   /**
@@ -236,9 +246,7 @@ class Group extends Emitter {
 
       resolve && this.resolve()
 
-      if (this.timeline) {
-        gsap.killTimeline(this.timeline)
-      } else {
+      if (!this.reset()) {
         this.timeline = new config.gsap.timeline({ paused: true }) // eslint-disable-line new-cap
       }
 

--- a/src/group/keyframe.js
+++ b/src/group/keyframe.js
@@ -67,6 +67,11 @@ class Keyframe extends Emitter {
     return this._prev
   }
 
+  /**
+   * Get the  value
+   *
+   * @returns {*}
+   */
   get value() {
     if (this.isEval()) {
       // create available mappings for current value
@@ -105,6 +110,11 @@ class Keyframe extends Emitter {
     return this._value
   }
 
+  /**
+   * Set value
+   *
+   * @param {*} val
+   */
   @emitChange()
   set value(val) {
     this._value = val

--- a/src/group/timeline.js
+++ b/src/group/timeline.js
@@ -93,6 +93,10 @@ class Timeline extends Emitter {
 
       this.props.mappings = [...this.props.mappings]
     }
+
+    if (this.type === 'dom' && transformObject instanceof window.Element) {
+      this._style = transformObject.getAttribute('style')
+    }
   }
 
   get transformObject() {

--- a/src/utils/emitter.js
+++ b/src/utils/emitter.js
@@ -141,7 +141,7 @@ const setter = function(target, key, descriptor) {
  * @param {*}       defaultValue  (optional, default=null)
  * @param {Array}   validators    (optional)
  */
-export function emitChange(prop, defaultValue = null, validators = []) {
+export function emitChange(prop = null, defaultValue = null, validators = []) {
   if (prop) {
     // bind as class
     return function(target) {


### PR DESCRIPTION
GSAP fucks up existing styling. Reset styles manually on `group.reset()`. 

From:

![](https://user-images.githubusercontent.com/232559/34219286-f8df2eba-e5b0-11e7-904f-189fd10fb63f.gif)

To:

![](https://user-images.githubusercontent.com/232559/34219308-0e526e42-e5b1-11e7-8986-c0a92e10b7e8.gif)


