### PR TITLE
Update timeline path on resolve elements

### DIFF
--- a/src/group/group.js
+++ b/src/group/group.js
@@ -1,5 +1,5 @@
 import config from '../config/config'
-import { gsap, debug, resolver } from '../utils'
+import { gsap, debug, resolver, xpath } from '../utils'
 import Timelines from './timelines'
 import { emitChange } from '../utils/emitter'
 import { TimelineError } from '../utils/errors'
@@ -208,6 +208,11 @@ class Group extends Emitter {
     this.timelines.each(timeline => {
       if (timeline.type === 'dom') {
         timeline.transformObject = !root ? null : resolver.resolveElement(root, timeline)
+
+        if (timeline.transformObject) {
+          timeline.path = xpath.getExpression(timeline.transformObject, root)
+        }
+
         if (!hasUnresolved && !timeline.transformObject) {
           hasUnresolved = true
         }

--- a/test/groups-spec.js
+++ b/test/groups-spec.js
@@ -2,6 +2,7 @@ import config from '../src/config/config'
 import { Groups, Group, Timelines } from '../src/group'
 import setup from '../src/config/setup'
 import { simpleGroups } from './fixtures/group/groups'
+import { is } from '../src/utils'
 
 const configGsap = { ...config.gsap }
 
@@ -72,6 +73,14 @@ describe('groups', () => {
           document.createElement('div'),
           document.createElement('div')
         ]
+
+    before(() => {
+      sinon.stub(is, 'isSVG', element => ['SVG', 'G', 'RECT'].includes(element.nodeName))
+    })
+
+    after(() => {
+      is.isSVG.restore()
+    })
 
     beforeEach(() => {
       data = simpleGroups[0]


### PR DESCRIPTION
**Description:**

Update timeline paths on resolve group. 

**Related issue (if exists):**

The `timeline.path` never updates, however when selecting a timeline in Spirit Studio, the timeline cannot be found.
